### PR TITLE
Linux Compilation Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Build artifacts
+*.o
+
+# Make artifacts
+Makefile
+
+# Configuration artifacts
+config.cache
+config.h
+config.log
+config.status
+
+# Statically built artifacts
+es
+esdump
+y.output
+
+# Statically built C files
+initial.c
+sigmsgs.c
+token.h
+y.tab.c
+y.tab.h

--- a/prim-etc.c
+++ b/prim-etc.c
@@ -12,13 +12,16 @@ PRIM(result) {
 
 PRIM(echo) {
 	const char *eol = "\n";
-	if (list != NULL)
+	if (list != NULL) {
 		if (termeq(list->term, "-n")) {
 			eol = "";
 			list = list->next;
-		} else { if (termeq(list->term, "--")) {
-			list = list->next;
-		}}
+		} else {
+		       	if (termeq(list->term, "--")) {
+				list = list->next;
+			}
+		}
+	}
 	print("%L%s", list, " ", eol);
 	return true;
 }
@@ -70,16 +73,14 @@ PRIM(mul) {
  */
 PRIM(div) {
 	int64_t quot = 0;
-	if ((list != NULL) && (list->next != NULL)) {
-		quot = (int64_t)strtol(getstr(list->term), (char **)NULL, 10);
-		for (list = list->next; list != NULL; list = list->next) {
-			quot /= (int64_t)strtol(getstr(list->term), (char **)NULL, 10);
-		}
-		return mklist(mkstr(str("%ld", quot)), NULL);
-	} else {
-		/* XXX: Warns that there's no return statement here, may need refactoring */
+	if ((list == NULL) || (list->next == NULL)) {
 		fail("$&div", "Expected at least 2 integer arguments");
 	}
+	quot = (int64_t)strtol(getstr(list->term), (char **)NULL, 10);
+	for (list = list->next; list != NULL; list = list->next) {
+		quot /= (int64_t)strtol(getstr(list->term), (char **)NULL, 10);
+	}
+	return mklist(mkstr(str("%ld", quot)), NULL);
 }
 
 /* 

--- a/prim-sys.c
+++ b/prim-sys.c
@@ -4,6 +4,7 @@
 
 #include "es.h"
 #include "prim.h"
+#include <sys/stat.h>
 
 #ifdef HAVE_SETRLIMIT
 # define BSD_LIMITS 1
@@ -17,6 +18,8 @@
 #if !HAVE_WAIT3
 #include <sys/times.h>
 #include <limits.h>
+#else
+#include <time.h>
 #endif
 #endif
 

--- a/print.c
+++ b/print.c
@@ -87,10 +87,10 @@ static void intconv(Format *format, unsigned int radix, int upper, char *altform
 		return;
 
 	flags = format->flags;
+	// Short gets default promoted to 'int' with va_arg, so
+	// no need to check FMT_short.
 	if (flags & FMT_long)
 		n = va_arg(format->args, long);
-	else if (flags & FMT_short)
-		n = va_arg(format->args, short);
 	else
 		n = va_arg(format->args, int);
 

--- a/proc.c
+++ b/proc.c
@@ -7,6 +7,7 @@
 #if HAVE_WAIT3
 #include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/wait.h>
 #endif
 
 Boolean hasforked = FALSE;

--- a/status.c
+++ b/status.c
@@ -72,10 +72,11 @@ extern void printstatus(int pid, int status) {
 			if (*msg == '\0')
 				tail += (sizeof "--") - 1;
 		}
-		if (*msg != '\0' || *tail != '\0')
+		if (*msg != '\0' || *tail != '\0') {
 			if (pid == 0)
 				eprint("%s%s\n", msg, tail);
 			else
 				eprint("%d: %s%s\n", pid, msg, tail);
+		}
 	}
 }

--- a/stdenv.h
+++ b/stdenv.h
@@ -71,7 +71,9 @@ extern Dirent *readdir(DIR *);
 #include <fcntl.h>
 #endif
 
+#if !defined(__unix__)
 #include <sys/wait.h>
+#endif
 
 /* stdlib */
 /* 


### PR DESCRIPTION
*- .gitignore
--> Added initial .gitignore.

*- prim-etc.c
--> Fixing warnings related to hanging else statements.
--> Refactoring return in `PRIM(div)` to not have a non-return.

*- prim-sys.c
--> Including `sys/stat.h` header to fix implicit function warnings.
--> Including `time.h` to fix implicit function warnings.

*- print.c
--> Fixing warnings related to default escalation of data types for va_args (short->int).

*- proc.c
--> Adding `sys/wait.h` to remove warnings related to implicit function declaration.

*- status.c
--> Fixing warnings related to hanging else statements.

*- stdenv.h
--> Fixing include for `sys/wait.h` in `stdenv.h`, which caused an issue during compilation; doing a check there for if system is not UNIX